### PR TITLE
Stage one contract restrictions

### DIFF
--- a/contracts/BondingCurve.sol
+++ b/contracts/BondingCurve.sol
@@ -60,14 +60,6 @@ contract BondingCurve is AccessControl {
         _;
     }
 
-    function setUpdater(address _updater) external {
-        grantRole(UPDATER, _updater);
-    }
-
-    function setCalculator(address _calculator) external {
-        grantRole(CALCULATOR, _calculator);
-    }
-
     function readOnlyCalculatePrice(uint256 _euroAmount) external view returns (uint256) {
         // fetches the price of euros based on the *current* discount price, therefore not completely accurate
         return convertEuroToSeuro(_euroAmount, currentBucket.price);

--- a/contracts/BondingCurve.sol
+++ b/contracts/BondingCurve.sol
@@ -5,8 +5,6 @@ import "contracts/SEuro.sol";
 import "abdk-libraries-solidity/ABDKMath64x64.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 
-import "hardhat/console.sol";
-
 contract BondingCurve is AccessControl {
     struct Bucket {
         uint32 index;

--- a/contracts/SEuroCalculator.sol
+++ b/contracts/SEuroCalculator.sol
@@ -3,19 +3,31 @@ pragma solidity ^0.8.0;
 
 import "contracts/BondingCurve.sol";
 import "contracts/interfaces/Chainlink.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
 
-contract SEuroCalculator {
+contract SEuroCalculator is AccessControl {
     uint256 public constant FIXED_POINT = 1_000_000_000_000_000_000;
+	bytes32 public constant OFFERING = keccak256("OFFERING");
 
     address public immutable EUR_USD_CL;
     uint8 public immutable EUR_USD_CL_DEC;
+	bytes32 public constant DEFAULT_ADMIN = keccak256("DEFAULT_ADMIN");
 
     BondingCurve private bondingCurve;
 
     constructor(address _bondingCurve, address _eurUsdCl, uint8 _eurUsdDec) {
+        _grantRole(DEFAULT_ADMIN, msg.sender);
+        _setRoleAdmin(OFFERING, DEFAULT_ADMIN);
+		grantRole(OFFERING, msg.sender);
+
         bondingCurve = BondingCurve(_bondingCurve);
         EUR_USD_CL = _eurUsdCl;
         EUR_USD_CL_DEC = _eurUsdDec;
+    }
+
+    modifier onlyOffering {
+		require(hasRole(OFFERING, msg.sender), "invalid-user");
+        _;
     }
 
     function calculateBaseRate(address _tokUsdCl, uint8 _tokUsdDec) private view returns (uint256) {
@@ -24,7 +36,7 @@ contract SEuroCalculator {
         return FIXED_POINT * uint256(tokUsd) / uint256(eurUsd) / 10 ** (_tokUsdDec - EUR_USD_CL_DEC);
     }
 
-    function calculate(uint256 _amount, address _tokUsdCl, uint8 _tokUsdDec) external returns (uint256) {
+    function calculate(uint256 _amount, address _tokUsdCl, uint8 _tokUsdDec) external onlyOffering returns (uint256) {
         uint256 euros = calculateBaseRate(_tokUsdCl, _tokUsdDec) * _amount / FIXED_POINT;
         return bondingCurve.calculatePrice(euros);
     }

--- a/scripts/deploymentStages.js
+++ b/scripts/deploymentStages.js
@@ -92,8 +92,8 @@ const mintUser = async (address) => {
 
 const giveContractsRequiredPermissions = async () => {
   await SEuro.grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address);
-  await BondingCurve.setUpdater(SEuroOffering.address);
-  await BondingCurve.setCalculator(SEuroCalculator.address);
+  await BondingCurve.grantRole(await BondingCurve.UPDATER(), SEuroOffering.address);
+  await BondingCurve.grantRole(await BondingCurve.CALCULATOR(), SEuroCalculator.address);
   await OperatorStage2.setStorage(BondStorage.address);
   await OperatorStage2.setBonding(BondingEvent.address);
   await OperatorStage2.setGateway(StandardTokenGateway.address);

--- a/scripts/deploymentStages.js
+++ b/scripts/deploymentStages.js
@@ -2,7 +2,7 @@ const { ethers, network } = require('hardhat');
 const fs = require('fs');
 const { encodePriceSqrt, MOST_STABLE_FEE, etherBalances } = require('../test/common');
 let addresses;
-let DummyTST, DummyUSDT, SEuro, SEuroOffering, OperatorStage2, BondStorage, BondingEvent, StandardTokenGateway, BondingCurve;
+let DummyTST, DummyUSDT, SEuro, SEuroOffering, OperatorStage2, BondStorage, BondingEvent, StandardTokenGateway, BondingCurve, SEuroCalculator;
 
 const INITIAL_PRICE = ethers.utils.parseEther('0.8');
 const MAX_SUPPLY = ethers.utils.parseEther('200000000');
@@ -39,7 +39,7 @@ const deployContracts = async () => {
   await completed(SEuro, 'SEuro');
   BondingCurve = await (await ethers.getContractFactory('BondingCurve')).deploy(SEuro.address, INITIAL_PRICE, MAX_SUPPLY, BUCKET_SIZE);
   await completed(BondingCurve, 'BondingCurve')
-  const SEuroCalculator = await (await ethers.getContractFactory('SEuroCalculator')).deploy(BondingCurve.address, externalContracts.eurUsdCl.address, externalContracts.eurUsdCl.dec);
+  SEuroCalculator = await (await ethers.getContractFactory('SEuroCalculator')).deploy(BondingCurve.address, externalContracts.eurUsdCl.address, externalContracts.eurUsdCl.dec);
   await completed(SEuroCalculator, 'SEuroCalculator')
   const TokenManager = await (await ethers.getContractFactory('TokenManager')).deploy(externalContracts.weth, externalContracts.ethUsdCl.address, externalContracts.ethUsdCl.dec);
   await completed(TokenManager, 'TokenManager')
@@ -93,6 +93,7 @@ const mintUser = async (address) => {
 const giveContractsRequiredPermissions = async () => {
   await SEuro.grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address);
   await BondingCurve.setUpdater(SEuroOffering.address);
+  await BondingCurve.setCalculator(SEuroCalculator.address);
   await OperatorStage2.setStorage(BondStorage.address);
   await OperatorStage2.setBonding(BondingEvent.address);
   await OperatorStage2.setGateway(StandardTokenGateway.address);

--- a/scripts/deploymentStages.js
+++ b/scripts/deploymentStages.js
@@ -91,7 +91,8 @@ const mintUser = async (address) => {
 }
 
 const giveContractsRequiredPermissions = async () => {
-  await SEuro.grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address);
+  await SEuro.grantRole(await SEuro.MINTER_ROLE(), SEuroOffering.address);
+  await SEuroCalculator.grantRole(await SEuroCalculator.OFFERING(), SEuroOffering.address);
   await BondingCurve.grantRole(await BondingCurve.UPDATER(), SEuroOffering.address);
   await BondingCurve.grantRole(await BondingCurve.CALCULATOR(), SEuroCalculator.address);
   await OperatorStage2.setStorage(BondStorage.address);

--- a/scripts/deploymentStages.js
+++ b/scripts/deploymentStages.js
@@ -2,7 +2,7 @@ const { ethers, network } = require('hardhat');
 const fs = require('fs');
 const { encodePriceSqrt, MOST_STABLE_FEE, etherBalances } = require('../test/common');
 let addresses;
-let DummyTST, DummyUSDT, SEuro, SEuroOffering, OperatorStage2, BondStorage, BondingEvent, StandardTokenGateway;
+let DummyTST, DummyUSDT, SEuro, SEuroOffering, OperatorStage2, BondStorage, BondingEvent, StandardTokenGateway, BondingCurve;
 
 const INITIAL_PRICE = ethers.utils.parseEther('0.8');
 const MAX_SUPPLY = ethers.utils.parseEther('200000000');
@@ -37,7 +37,7 @@ const deployContracts = async () => {
   await completed(DummyUSDT, 'USDT');
   SEuro = await (await ethers.getContractFactory('SEuro')).deploy('sEURO', 'SEUR', []);
   await completed(SEuro, 'SEuro');
-  const BondingCurve = await (await ethers.getContractFactory('BondingCurve')).deploy(SEuro.address, INITIAL_PRICE, MAX_SUPPLY, BUCKET_SIZE);
+  BondingCurve = await (await ethers.getContractFactory('BondingCurve')).deploy(SEuro.address, INITIAL_PRICE, MAX_SUPPLY, BUCKET_SIZE);
   await completed(BondingCurve, 'BondingCurve')
   const SEuroCalculator = await (await ethers.getContractFactory('SEuroCalculator')).deploy(BondingCurve.address, externalContracts.eurUsdCl.address, externalContracts.eurUsdCl.dec);
   await completed(SEuroCalculator, 'SEuroCalculator')
@@ -92,6 +92,7 @@ const mintUser = async (address) => {
 
 const giveContractsRequiredPermissions = async () => {
   await SEuro.grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address);
+  await BondingCurve.setUpdater(SEuroOffering.address);
   await OperatorStage2.setStorage(BondStorage.address);
   await OperatorStage2.setBonding(BondingEvent.address);
   await OperatorStage2.setGateway(StandardTokenGateway.address);

--- a/scripts/testnetContractsUserReady.js
+++ b/scripts/testnetContractsUserReady.js
@@ -6,6 +6,7 @@ async function main() {
   const addresses = JSON.parse(fs.readFileSync('scripts/testnetDeploymentArtifact.json')).contractAddresses
 
   const SEuroOffering = await ethers.getContractAt('SEuroOffering', addresses.SEuroOffering);
+  const BondingCurve = await ethers.getContractAt('BondingCurve', addresses.BondingCurve);
   const USDT = await ethers.getContractAt('DUMMY', addresses.USDT);
   const TokenManager = await ethers.getContractAt('TokenManager', addresses.TokenManager);
   const SEuro = await ethers.getContractAt('SEuro', addresses.SEuro);
@@ -17,6 +18,7 @@ async function main() {
 
   await SEuroOffering.activate();
   await SEuro.grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address);
+  await BondingCurve.setUpdater(SEuroOffering.address);
   await TokenManager.addAcceptedToken(ethers.utils.formatBytes32String("USDT"), USDT.address, '0x2bA49Aaa16E6afD2a993473cfB70Fa8559B523cF', 8);
   await OperatorStage2.setStorage(BondStorage.address);
   await OperatorStage2.setBonding(BondingEvent.address);

--- a/scripts/testnetContractsUserReady.js
+++ b/scripts/testnetContractsUserReady.js
@@ -18,7 +18,8 @@ async function main() {
   const TST = await ethers.getContractAt('DUMMY', addresses.TST);
 
   await SEuroOffering.activate();
-  await SEuro.grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address);
+  await SEuro.grantRole(await SEuro.MINTER_ROLE(), SEuroOffering.address);
+  await SEuroCalculator.grantRole(await SEuroCalculator.OFFERING(), SEuroOffering.address);
   await BondingCurve.grantRole(await BondingCurve.UPDATER(), SEuroOffering.address);
   await BondingCurve.grantRole(await BondingCurve.CALCULATOR(), SEuroCalculator.address);
   await TokenManager.addAcceptedToken(ethers.utils.formatBytes32String("USDT"), USDT.address, '0x2bA49Aaa16E6afD2a993473cfB70Fa8559B523cF', 8);

--- a/scripts/testnetContractsUserReady.js
+++ b/scripts/testnetContractsUserReady.js
@@ -19,8 +19,8 @@ async function main() {
 
   await SEuroOffering.activate();
   await SEuro.grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address);
-  await BondingCurve.setUpdater(SEuroOffering.address);
-  await BondingCurve.setCalculator(SEuroCalculator.address);
+  await BondingCurve.grantRole(await BondingCurve.UPDATER(), SEuroOffering.address);
+  await BondingCurve.grantRole(await BondingCurve.CALCULATOR(), SEuroCalculator.address);
   await TokenManager.addAcceptedToken(ethers.utils.formatBytes32String("USDT"), USDT.address, '0x2bA49Aaa16E6afD2a993473cfB70Fa8559B523cF', 8);
   await OperatorStage2.setStorage(BondStorage.address);
   await OperatorStage2.setBonding(BondingEvent.address);

--- a/scripts/testnetContractsUserReady.js
+++ b/scripts/testnetContractsUserReady.js
@@ -7,6 +7,7 @@ async function main() {
 
   const SEuroOffering = await ethers.getContractAt('SEuroOffering', addresses.SEuroOffering);
   const BondingCurve = await ethers.getContractAt('BondingCurve', addresses.BondingCurve);
+  const SEuroCalculator = await ethers.getContractAt('SEuroCalculator', addresses.SEuroCalculator);
   const USDT = await ethers.getContractAt('DUMMY', addresses.USDT);
   const TokenManager = await ethers.getContractAt('TokenManager', addresses.TokenManager);
   const SEuro = await ethers.getContractAt('SEuro', addresses.SEuro);
@@ -19,6 +20,7 @@ async function main() {
   await SEuroOffering.activate();
   await SEuro.grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address);
   await BondingCurve.setUpdater(SEuroOffering.address);
+  await BondingCurve.setCalculator(SEuroCalculator.address);
   await TokenManager.addAcceptedToken(ethers.utils.formatBytes32String("USDT"), USDT.address, '0x2bA49Aaa16E6afD2a993473cfB70Fa8559B523cF', 8);
   await OperatorStage2.setStorage(BondStorage.address);
   await OperatorStage2.setBonding(BondingEvent.address);

--- a/test/bondingCurve.js
+++ b/test/bondingCurve.js
@@ -79,7 +79,7 @@ describe('BondingCurve', async () => {
       const euros = ethers.utils.parseEther('1');
       await expect(BondingCurve.connect(calculator).calculatePrice(euros)).to.be.revertedWith('invalid-user');
 
-      await BondingCurve.setCalculator(calculator.address);
+      await BondingCurve.grantRole(await BondingCurve.CALCULATOR(), calculator.address);
       await expect(BondingCurve.connect(calculator).calculatePrice(euros)).not.to.be.revertedWith('invalid-user');
     });
   });
@@ -87,7 +87,7 @@ describe('BondingCurve', async () => {
   describe('updateCurrentBucket', async () => {
     it('saves new bucket price when supply has changed, if requested by SEuroOffering', async () => {
       // give updater access to update price bucket
-      await BondingCurve.setUpdater(updater.address);
+      await BondingCurve.grantRole(await BondingCurve.UPDATER(), updater.address);
 
       const bucket0Price = await getBucketPrice(0);
       const bucket1Price = await getBucketPrice(1);

--- a/test/bondingCurve.js
+++ b/test/bondingCurve.js
@@ -9,7 +9,7 @@ describe('BondingCurve', async () => {
   const INITIAL_PRICE = ethers.utils.parseEther('0.8');
 
   beforeEach(async () => {
-    [owner] = await ethers.getSigners();
+    [owner, customer, updater] = await ethers.getSigners();
 
     const BondingCurveContract = await ethers.getContractFactory('BondingCurve');
     const SEuroContract = await ethers.getContractFactory('SEuro');
@@ -77,13 +77,18 @@ describe('BondingCurve', async () => {
   });
 
   describe('updateCurrentBucket', async () => {
-    it('saves new bucket price when supply has changed', async () => {
-      await SEuro.mint(owner.address, BUCKET_SIZE);
-      await BondingCurve.updateCurrentBucket(BUCKET_SIZE);
+    it('saves new bucket price when supply has changed, if requested by SEuroOffering', async () => {
+      // give updater access to update price bucket
+      await BondingCurve.setUpdater(updater.address);
 
-      const newBucketPrice = (await BondingCurve.currentBucket()).price;
+      const bucket0Price = await getBucketPrice(0);
+      const bucket1Price = await getBucketPrice(1);
 
-      expect(newBucketPrice).to.equal(await getBucketPrice(1));
+      await expect(BondingCurve.connect(customer).updateCurrentBucket(BUCKET_SIZE)).to.be.revertedWith('invalid-user');
+      expect((await BondingCurve.currentBucket()).price).to.equal(bucket0Price);
+
+      await BondingCurve.connect(updater).updateCurrentBucket(BUCKET_SIZE);
+      expect((await BondingCurve.currentBucket()).price).to.equal(bucket1Price);
     });
   });
 

--- a/test/bondingCurve.js
+++ b/test/bondingCurve.js
@@ -9,7 +9,7 @@ describe('BondingCurve', async () => {
   const INITIAL_PRICE = ethers.utils.parseEther('0.8');
 
   beforeEach(async () => {
-    [owner, customer, updater] = await ethers.getSigners();
+    [owner, customer, updater, calculator] = await ethers.getSigners();
 
     const BondingCurveContract = await ethers.getContractFactory('BondingCurve');
     const SEuroContract = await ethers.getContractFactory('SEuro');
@@ -73,6 +73,14 @@ describe('BondingCurve', async () => {
       const seuros = await BondingCurve.callStatic.calculatePrice(euros);
 
       expect(seuros).to.equal(euros);
+    });
+
+    it('only allows calculator role to calculate price', async () => {
+      const euros = ethers.utils.parseEther('1');
+      await expect(BondingCurve.connect(calculator).calculatePrice(euros)).to.be.revertedWith('invalid-user');
+
+      await BondingCurve.setCalculator(calculator.address);
+      await expect(BondingCurve.connect(calculator).calculatePrice(euros)).not.to.be.revertedWith('invalid-user');
     });
   });
 

--- a/test/bondingCurve.js
+++ b/test/bondingCurve.js
@@ -80,7 +80,7 @@ describe('BondingCurve', async () => {
       await expect(BondingCurve.connect(calculator).calculatePrice(euros)).to.be.revertedWith('invalid-user');
 
       await BondingCurve.grantRole(await BondingCurve.CALCULATOR(), calculator.address);
-      await expect(BondingCurve.connect(calculator).calculatePrice(euros)).not.to.be.revertedWith('invalid-user');
+      await expect(BondingCurve.connect(calculator).calculatePrice(euros)).not.to.be.reverted;
     });
   });
 

--- a/test/seuroOffering.js
+++ b/test/seuroOffering.js
@@ -58,6 +58,7 @@ describe('SEuroOffering', async () => {
 
     await SEuro.connect(owner).grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address)
     await BondingCurve.setUpdater(SEuroOffering.address);
+    await BondingCurve.setCalculator(SEuroCalculator.address);
   });
 
   describe('swap', async () => {

--- a/test/seuroOffering.js
+++ b/test/seuroOffering.js
@@ -57,8 +57,8 @@ describe('SEuroOffering', async () => {
     SEuroOffering = await SEuroOfferingContract.deploy(SEuro.address, SEuroCalculator.address, TokenManager.address, BondingCurve.address);
 
     await SEuro.connect(owner).grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address)
-    await BondingCurve.setUpdater(SEuroOffering.address);
-    await BondingCurve.setCalculator(SEuroCalculator.address);
+    await BondingCurve.grantRole(await BondingCurve.UPDATER(), SEuroOffering.address);
+    await BondingCurve.grantRole(await BondingCurve.CALCULATOR(), SEuroCalculator.address);
   });
 
   describe('swap', async () => {

--- a/test/seuroOffering.js
+++ b/test/seuroOffering.js
@@ -57,6 +57,7 @@ describe('SEuroOffering', async () => {
     SEuroOffering = await SEuroOfferingContract.deploy(SEuro.address, SEuroCalculator.address, TokenManager.address, BondingCurve.address);
 
     await SEuro.connect(owner).grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address)
+    await BondingCurve.setUpdater(SEuroOffering.address);
   });
 
   describe('swap', async () => {

--- a/test/seuroOffering.js
+++ b/test/seuroOffering.js
@@ -57,6 +57,7 @@ describe('SEuroOffering', async () => {
     SEuroOffering = await SEuroOfferingContract.deploy(SEuro.address, SEuroCalculator.address, TokenManager.address, BondingCurve.address);
 
     await SEuro.connect(owner).grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), SEuroOffering.address)
+    await SEuroCalculator.grantRole(await SEuroCalculator.OFFERING(), SEuroOffering.address);
     await BondingCurve.grantRole(await BondingCurve.UPDATER(), SEuroOffering.address);
     await BondingCurve.grantRole(await BondingCurve.CALCULATOR(), SEuroCalculator.address);
   });

--- a/test/seuroRateCalculator.js
+++ b/test/seuroRateCalculator.js
@@ -23,6 +23,7 @@ describe('SEuroCalculator', async () => {
     BondingCurve = await BondingCurveContract.deploy(SEuro.address, INITIAL_PRICE, MAX_SUPPLY, BUCKET_SIZE);
     const SEuroCalculatorContract = await ethers.getContractFactory('SEuroCalculator');
     SEuroCalculator = await SEuroCalculatorContract.deploy(BondingCurve.address, EUR_USD_CL, EUR_USD_CL_DEC);
+    await BondingCurve.setCalculator(SEuroCalculator.address);
   });
 
   async function getBaseEurRate(clTokUsd) {

--- a/test/seuroRateCalculator.js
+++ b/test/seuroRateCalculator.js
@@ -54,12 +54,13 @@ describe('SEuroCalculator', async () => {
     expect(seuros).to.equal(await expectedSEuros(CL_DAI_USD, amount));
   });
 
-  // it('does not do state-changing calculation unless called by offering contract', async () => {
-  //   const amount = etherBalances['10K'];
-  //   await expect(SEuroCalculator.calculate(amount, CL_DAI_USD, CL_DAI_USD_DEC)).to.be.revertedWith('invalid-user');
+  it('does not do state-changing calculation unless called by offering contract', async () => {
+    const amount = etherBalances['10K'];
+    await expect(SEuroCalculator.connect(offering).calculate(amount, CL_DAI_USD, CL_DAI_USD_DEC)).to.be.revertedWith('invalid-user');
 
-  //   await SEuroCalculator.setOffering()
-  // });
+    await SEuroCalculator.grantRole(await SEuroCalculator.OFFERING(), offering.address);
+    await expect(SEuroCalculator.connect(offering).calculate(amount, CL_DAI_USD, CL_DAI_USD_DEC)).not.to.be.reverted;
+  });
 
   it('calculates using read-only bonding curve', async () => {
     const amount = etherBalances.TWO_MILLION;


### PR DESCRIPTION
resolves #27 

- restricts calling of `BondingCurve.updateCurrentBucket()` to the UPDATER role
- restricts calling of `BondingCurve.calculatePrice()` to the CALCULATOR role
- restricts calling of `SEuroCalculator.calculate()` to the OFFERING role

i restricted the use of `calculatePrice` because this uses the intense bonding curve calculations (and caches, changing the state). but thinking about maybe we're happy for an anonymous user to call this, as long as they're happy to pay the gas? the only state it changes is the cache. happy to discuss further