### PR TITLE
Extend operator with allowed rates and maturities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ cov:
 
 size:
 		@npx hardhat size-contracts
+
+lint:
+		@npx eslint test/

--- a/contracts/OperatorStage2.sol
+++ b/contracts/OperatorStage2.sol
@@ -88,11 +88,11 @@ contract OperatorStage2 is AccessControl {
 	function newBond(
 		address _user,
 		uint256 _amountSeuro,
-		uint256 _weeks,
 		uint256 _rate
 	) public {
-		require(allowedYieldToWeeks[_rate] > 0, "err-missing-rate");
-		bondingEvent.bond(_user, _amountSeuro, _weeks, _rate);
+		uint256 wks = allowedYieldToWeeks[_rate];
+		require(wks > 0, "err-missing-rate");
+		bondingEvent.bond(_user, _amountSeuro, wks, _rate);
 	}
 
 	function refreshBond(address _user) public {

--- a/test/operatorStage2.js
+++ b/test/operatorStage2.js
@@ -63,7 +63,7 @@ describe('Stage 2', async () => {
 
         async function testingSuite(seuroAmount, inputRate, inputDurationWeeks) {
           await OP2.connect(owner).newBond(
-            customer.address, seuroAmount, inputDurationWeeks, inputRate
+            customer.address, seuroAmount, inputRate
           );
 
           await BStorage.connect(customer).refreshBondStatus(customer.address);

--- a/test/operatorStage2.js
+++ b/test/operatorStage2.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const bn = require('bignumber.js');
-const { POSITION_MANAGER_ADDRESS, STANDARD_TOKENS_PER_EUR, DECIMALS, etherBalances, rates, durations, ONE_WEEK_IN_SECONDS, MOST_STABLE_FEE, helperFastForwardTime, DEFAULT_SQRT_PRICE, MIN_TICK, MAX_TICK } = require('./common.js');
+const { POSITION_MANAGER_ADDRESS, STANDARD_TOKENS_PER_EUR, DECIMALS, etherBalances, rates, ONE_WEEK_IN_SECONDS, MOST_STABLE_FEE, helperFastForwardTime, DEFAULT_SQRT_PRICE, MIN_TICK, MAX_TICK } = require('./common.js');
 bn.config({ EXPONENTIAL_AT: 999999, DECIMAL_PLACES: 40 });
 
 let owner, customer, SEuro, TST, USDT;
@@ -109,30 +109,30 @@ describe('Stage 2', async () => {
           let threePercent = 3000;
           let arbitraryWeeks = 36;
           await expect(testingSuite(etherBalances['125K'], threePercent, arbitraryWeeks)).to.be.revertedWith('err-missing-rate');
-       });
+        });
 
-       it('adds and subtracts multiple new rates to grow and shrink the set of accepted rates', async() => {
-         let expectedRates, actualRates;
-         await OP2.connect(owner).addRate(rates.FIVE_PC, 10);
-         await OP2.connect(owner).addRate(rates.TEN_PC, 20);
-         await OP2.connect(owner).addRate(rates.TWENTY_PC, 40);
+        it('adds and subtracts multiple new rates to grow and shrink the set of accepted rates', async() => {
+          let expectedRates, actualRates;
+          await OP2.connect(owner).addRate(rates.FIVE_PC, 10);
+          await OP2.connect(owner).addRate(rates.TEN_PC, 20);
+          await OP2.connect(owner).addRate(rates.TWENTY_PC, 40);
 
-         expectedRates = 4;
-         actualRates = (await OP2.showRates()).length;
-         expect(actualRates).to.equal(expectedRates);
+          expectedRates = 4;
+          actualRates = (await OP2.showRates()).length;
+          expect(actualRates).to.equal(expectedRates);
 
-         await OP2.removeRate(rates.TWENTY_PC);
-         await OP2.removeRate(rates.TEN_PC);
-         expectedRates = 2;
-         actualRates = (await OP2.showRates()).length;
-         expect(actualRates).to.equal(expectedRates);
-       });
+          await OP2.removeRate(rates.TWENTY_PC);
+          await OP2.removeRate(rates.TEN_PC);
+          expectedRates = 2;
+          actualRates = (await OP2.showRates()).length;
+          expect(actualRates).to.equal(expectedRates);
+        });
 
-       it('adds a rate and bonds successfully, then removes it such that following bonding fails', async() => {
-         await OP2.connect(owner).addRate(rates.FIVE_PC, 10);
-         await testingSuite(etherBalances['125K'], rates.FIVE_PC, 10);
-         await OP2.connect(owner).removeRate(rates.FIVE_PC);
-         await expect(testingSuite(etherBalances['125K'], rates.FIVE_PC, 10)).to.be.revertedWith('err-missing-rate');
+        it('adds a rate and bonds successfully, then removes it such that following bonding fails', async() => {
+          await OP2.connect(owner).addRate(rates.FIVE_PC, 10);
+          await testingSuite(etherBalances['125K'], rates.FIVE_PC, 10);
+          await OP2.connect(owner).removeRate(rates.FIVE_PC);
+          await expect(testingSuite(etherBalances['125K'], rates.FIVE_PC, 10)).to.be.revertedWith('err-missing-rate');
         });
       });
     });

--- a/test/operatorStage2.js
+++ b/test/operatorStage2.js
@@ -77,9 +77,9 @@ describe('Stage 2', async () => {
           expect(actualPrincipal).to.equal(etherBalances['125K']);
           expect(actualRate).to.equal(inputRate);
 
-		  if (inputDurationWeeks == 0) {
-			inputDurationWeeks = 52;
-		  }
+          if (inputDurationWeeks == 0) {
+            inputDurationWeeks = 52;
+          }
 
           await helperFastForwardTime(inputDurationWeeks * ONE_WEEK_IN_SECONDS);
           await OP2.connect(customer).refreshBond(customer.address);
@@ -94,32 +94,32 @@ describe('Stage 2', async () => {
         }
 
         it('transfers TST rewards successfully when bonding with a custom rate', async () => {
-		  await OP2.connect(owner).addRate(rates.TWENTY_PC, 1);
+          await OP2.connect(owner).addRate(rates.TWENTY_PC, 1);
           await testingSuite(etherBalances['125K'], rates.TWENTY_PC, 1);
           await expectedTokBalance(125000, 1.2);
         });
 
-		it('transfers TST rewards successfully when bonding with the default rate', async () => {
-		  let twoPercent = 2000;
-		  await testingSuite(etherBalances['125K'], twoPercent, 52);
-		  await expectedTokBalance(125000, 1.02);
-		});
+        it('transfers TST rewards successfully when bonding with the default rate', async () => {
+          let twoPercent = 2000;
+          await testingSuite(etherBalances['125K'], twoPercent, 52);
+          await expectedTokBalance(125000, 1.02);
+        });
 
-		it('reverts when trying to bond with a non-added rate', async () => {
-		  let threePercent = 3000;
-		  let arbitraryWeeks = 36;
-		  await expect(testingSuite(etherBalances['125K'], threePercent, arbitraryWeeks)).to.be.revertedWith('err-missing-rate');
-		});
+        it('reverts when trying to bond with a non-added rate', async () => {
+          let threePercent = 3000;
+          let arbitraryWeeks = 36;
+          await expect(testingSuite(etherBalances['125K'], threePercent, arbitraryWeeks)).to.be.revertedWith('err-missing-rate');
+       });
 
-		it('adds multiple new rates and grows the set of accepted rates', async() => {
-		  await OP2.connect(owner).addRate(rates.FIVE_PC, 10);
-		  await OP2.connect(owner).addRate(rates.TEN_PC, 20);
-		  await OP2.connect(owner).addRate(rates.TWENTY_PC, 40);
+       it('adds multiple new rates and grows the set of accepted rates', async() => {
+          await OP2.connect(owner).addRate(rates.FIVE_PC, 10);
+          await OP2.connect(owner).addRate(rates.TEN_PC, 20);
+          await OP2.connect(owner).addRate(rates.TWENTY_PC, 40);
 
-		  let expectedRates = 4;
-		  let actualRates = (await OP2.showRates()).length;
-		  expect(actualRates).to.equal(expectedRates);
-		});
+          let expectedRates = 4;
+          let actualRates = (await OP2.showRates()).length;
+          expect(actualRates).to.equal(expectedRates);
+       });
 
       });
     });


### PR DESCRIPTION
A user can call the bond function directly now. The operator is not in full control of bonding anymore but controls which interest rates a user are able to bond with.