### PR TITLE
ignore files for coverage + add optimiser

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,4 @@
+module.exports = {
+  skipFiles: ['test_utils', 'uniswap'],
+  configureYulOptimizer: true
+};


### PR DESCRIPTION
coverage runner has stack too deep errors. this adds the compiler optimisation to the coverage runner

it also ignores some contracts that we don't need to analyse the coverage of