### PR TITLE
Stage 2 catastrophe

### DIFF
--- a/contracts/Stage2/BondStorage.sol
+++ b/contracts/Stage2/BondStorage.sol
@@ -154,7 +154,7 @@ contract BondStorage is AccessControl {
 
     /// ================ BondStorage public APIs ==============
 
-    function startBond(address _user, uint256 _principalSeuro, uint256 _principalOther, uint256 _rate, uint256 _maturity, uint256 _tokenId, uint128 _liquidity) external onlyWhitelisted {
+    function startBond(address _user, uint256 _principalSeuro, uint256 _principalOther, uint256 _rate, uint256 _maturity, uint256 _tokenId, uint128 _liquidity) external onlyWhitelisted notInCatastrophe {
         // reduce the amount of available bonding reward TSTs
         (uint256 reward, uint256 profit) = potentialReward(_principalSeuro, _principalOther, _rate);
         tokenGateway.decreaseRewardSupply(reward);
@@ -187,7 +187,7 @@ contract BondStorage is AccessControl {
     }
 
     // Claims the payout in TST tokens by sending it to the user's wallet and resetting the claim to zero.
-    function claimReward(address _user) external ifActive(_user) {
+    function claimReward(address _user) external notInCatastrophe ifActive(_user) {
         uint256 reward = getClaimAmount(_user);
         require(reward > 0, "err-no-reward");
         tapUntappedBonds(_user);

--- a/contracts/Stage2/StandardTokenGateway.sol
+++ b/contracts/Stage2/StandardTokenGateway.sol
@@ -10,11 +10,9 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 // - price per token in EUR;
 // - amount of obtainable tokens as bonding rewards left
 contract StandardTokenGateway is AccessControl {
-    // Deployed TST contract on mainnet with a maximum supply of 1 billion tokens
-    address public constant TST_ADDRESS = 0xa0b93B9e90aB887E53F9FB8728c009746e989B53;
 
     // Reward token (TST)
-    IERC20 private immutable TOKEN;
+    IERC20 public immutable TOKEN;
 
     uint256 public priceTstEur = 5500000;
     uint8 public priceDec = 8;

--- a/contracts/Stage3/Staking.sol
+++ b/contracts/Stage3/Staking.sol
@@ -18,7 +18,7 @@ contract Staking is ERC721, Ownable, Pausable, Drainable {
     StandardTokenGateway public tokenGateway;
 
     bool public active;                 // active or not, needs to be set manually
-    bool public isCatastrophy;          // in the event of a catastrophy, let users withdraw
+    bool public isCatastrophe;          // in the event of a catastrophe, let users withdraw
 
     uint256 public windowStart;         // the start time for the 'stake'
     uint256 public windowEnd;           // the end time for the 'stake'
@@ -134,22 +134,22 @@ contract Staking is ERC721, Ownable, Pausable, Drainable {
 
     function position(address owner) external view returns (Position memory) { return _positions[owner]; }
 
-    function enableCatastrophy() external onlyOwner {
+    function enableCatastrophe() external onlyOwner {
         require(active == true, "err-already-active");
-        require(isCatastrophy == false, "err-already-isCatastrophy");
-        isCatastrophy = true;
+        require(isCatastrophe == false, "err-already-isCatastrophe");
+        isCatastrophe = true;
         active = false;
     }
 
-    function disableCatastrophy() external onlyOwner {
+    function disableCatastrophe() external onlyOwner {
         require(active == false, "err-already-active");
-        require(isCatastrophy == true, "err-already-isCatastrophy-false");
-        isCatastrophy = false;
+        require(isCatastrophe == true, "err-already-isCatastrophe-false");
+        isCatastrophe = false;
         active = true;
     }
 
     function emergencyWithdraw() external {
-        require(isCatastrophy == true, "err-not-catastrophy");
+        require(isCatastrophe == true, "err-not-catastrophe");
 
         Position memory pos = _positions[msg.sender];
         require(pos.nonce > 0, "err-no-position");

--- a/test/stage2/bondStorage.js
+++ b/test/stage2/bondStorage.js
@@ -1,25 +1,73 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
-const { CHAINLINK_DEC, getLibraryFactory } = require('../common.js');
+const { CHAINLINK_DEC, getLibraryFactory, etherBalances, parse6Dec, helperFastForwardTime, CHAINLINK_EUR_USD } = require('../common.js');
 
 describe('BondStorage', async () => {
-  let contractFactory, owner, customer, gateway1, gateway2, chainlinkFeed;
+  const deployAndMintGateway = async () => {
+    const TST = await erc20Contract.deploy('The Standard Token', 'TST', 18);
+    gateway = await (await ethers.getContractFactory('StandardTokenGateway')).deploy(TST.address);
+    await TST.mint(gateway.address, etherBalances.ONE_BILLION);
+    await gateway.updateRewardSupply();
+  }
+
+  let contractFactory, BondStorage, owner, customer, gateway, gateway2, Seuro, Other, erc20Contract;
   beforeEach(async () => {
-    [owner, customer, gateway1, gateway2, chainlinkFeed] = await ethers.getSigners();
+    [owner, customer, gateway2, user1, user2] = await ethers.getSigners();
     contractFactory = await getLibraryFactory(owner, 'BondStorage');
+    erc20Contract = await ethers.getContractFactory('DUMMY');
+    Seuro = await erc20Contract.deploy('sEURO', 'SEUR', 18);
+    Other = await erc20Contract.deploy('USD Coin', 'USDC', 6);
+    await deployAndMintGateway();
+    BondStorage = await contractFactory.deploy(gateway.address, CHAINLINK_EUR_USD, CHAINLINK_DEC, Seuro.address, Other.address);
+    await gateway.setStorageAddress(BondStorage.address);
   });
 
   describe('dependencies', async () => {
     it('allows owner to update token gateway dependency', async () => {
-      let BondStorage = await contractFactory.deploy(gateway1.address, chainlinkFeed.address, CHAINLINK_DEC);
-
       let update = BondStorage.connect(customer).setTokenGateway(gateway2.address);
       await expect(update).to.be.revertedWith('invalid-storage-operator');
-      expect(await BondStorage.tokenGateway()).to.equal(gateway1.address);
+      expect(await BondStorage.tokenGateway()).to.equal(gateway.address);
 
       update = BondStorage.connect(owner).setTokenGateway(gateway2.address);
       await expect(update).not.to.be.reverted;
       expect(await BondStorage.tokenGateway()).to.equal(gateway2.address);
+    });
+  });
+
+  describe('catastrophe', async () => {
+    let amountSeuro, amountOther;
+
+    const startBonds = async () => {
+      // start some bonds for two users
+      // two bonds not mature, one mature but not claimed, one claimed
+      // catastrophe should therefore only be active for three
+      amountSeuro = etherBalances['10K'];
+      amountOther = parse6Dec(5000);
+      const rate = 1000;
+      const day = 60 * 60 * 24;
+      const week = 7 * day;
+      // doesn't matter here:
+      const tokenId = 1; const liquidity = 100
+      await BondStorage.startBond(user1.address, amountSeuro, amountOther, rate, day, tokenId, liquidity);
+      await BondStorage.startBond(user2.address, amountSeuro, amountOther, rate, day, tokenId, liquidity);
+      await BondStorage.startBond(user1.address, amountSeuro, amountOther, rate, week, tokenId, liquidity);
+      await BondStorage.startBond(user2.address, amountSeuro, amountOther, rate, week, tokenId, liquidity);
+      await helperFastForwardTime(2 * day);
+      await BondStorage.claimReward(user1.address);
+    }
+
+    beforeEach(async () => {
+      await startBonds();
+    });
+
+    it('calculates required seuro / other in contract', async () => {
+      const expectedRequiredSeuro = amountSeuro.mul(3); // three live bonds
+      const expectedRequiredOther = amountOther.mul(3); // three live bonds
+
+      const { seuroRequired, otherRequired } = await BondStorage.catastropheFundsRequired();
+
+      expect(seuroRequired).to.eq(expectedRequiredSeuro);
+      expect(otherRequired).to.eq(expectedRequiredOther);
     });
   });
 });

--- a/test/stage2/bondingEvent.js
+++ b/test/stage2/bondingEvent.js
@@ -20,7 +20,7 @@ describe('BondingEvent', async () => {
     USDC = await ERC20Contract.deploy('USDC', 'USDC', 6);
     const ChainlinkEurUsd = await (await ethers.getContractFactory('Chainlink')).deploy(DEFAULT_CHAINLINK_EUR_USD_PRICE);
     TokenGateway = await TokenGatewayContract.deploy(TST.address);
-    BondStorage = await BondStorageContract.deploy(TokenGateway.address, ChainlinkEurUsd.address, SCALED_UP_CHAINLINK_DEC);
+    BondStorage = await BondStorageContract.deploy(TokenGateway.address, ChainlinkEurUsd.address, SCALED_UP_CHAINLINK_DEC, SEuro.address, USDC.address);
     RatioCalculator = await RatioCalculatorContract.deploy();
   });
 
@@ -500,7 +500,7 @@ describe('BondingEvent', async () => {
   describe('dependencies', async () => {
     it('allows the owner to update the dependencies', async () => {
       await deployBondingEventWithDefaultPrices();
-      const newStorage = await BondStorageContract.deploy(ethers.constants.AddressZero, ethers.constants.AddressZero, 0);
+      const newStorage = await BondStorageContract.deploy(ethers.constants.AddressZero, ethers.constants.AddressZero, 0, SEuro.address, USDC.address);
       const newOperator = await (await ethers.getContractFactory('OperatorStage2')).deploy();
       const newCalculator = await (await ethers.getContractFactory('RatioCalculator')).deploy();
 

--- a/test/stage2/bondingReward.js
+++ b/test/stage2/bondingReward.js
@@ -38,7 +38,7 @@ describe('BondingReward', async () => {
 
   describe('bonding', async () => {
     it('will not bond if no TST in gateway', async () => {
-      BStorage = await StorageContract.deploy(TGateway.address, ChainlinkEurUsd.address, CHAINLINK_DEC);
+      BStorage = await StorageContract.deploy(TGateway.address, ChainlinkEurUsd.address, CHAINLINK_DEC, SEuro.address, USDC.address);
       BondingEvent = await BondingEventContract.deploy(
         SEuro.address, USDC.address, POSITION_MANAGER_ADDRESS, BStorage.address, owner.address,
         RatioCalculator.address, DEFAULT_SQRT_PRICE, MIN_TICK, MAX_TICK, MOST_STABLE_FEE
@@ -65,7 +65,7 @@ describe('BondingReward', async () => {
 
       context('other asset is 18 dec token', async () => {
         beforeEach(async () => {
-          BStorage = await StorageContract.deploy(TGateway.address, ChainlinkEurUsd.address, CHAINLINK_DEC);
+          BStorage = await StorageContract.deploy(TGateway.address, ChainlinkEurUsd.address, CHAINLINK_DEC, SEuro.address, USDC.address);
           BondingEvent = await BondingEventContract.deploy(
             SEuro.address, USDC.address, POSITION_MANAGER_ADDRESS, BStorage.address, owner.address,
             RatioCalculator.address, DEFAULT_SQRT_PRICE, MIN_TICK, MAX_TICK, MOST_STABLE_FEE
@@ -128,7 +128,7 @@ describe('BondingReward', async () => {
   
         beforeEach(async () => {
           // storage chainlink decimals need to be scaled up to match seuro
-          BStorage = await StorageContract.deploy(TGateway.address, ChainlinkEurUsd.address, EUR_USD_CONVERSION_SCALE);
+          BStorage = await StorageContract.deploy(TGateway.address, ChainlinkEurUsd.address, EUR_USD_CONVERSION_SCALE, SEuro.address, USDT.address);
           const sixDecPrice = sortedPrice(scaleUpForDecDiff(100, 12), 105);
           BondingEvent = await BondingEventContract.deploy(
             SEuro.address, USDT.address, POSITION_MANAGER_ADDRESS, BStorage.address, owner.address,

--- a/test/stage2/operatorStage2.js
+++ b/test/stage2/operatorStage2.js
@@ -35,7 +35,7 @@ describe('Stage 2', async () => {
       RatioCalculator = await RatioCalculatorContract.deploy();
       const ChainlinkEurUsd = await (await ethers.getContractFactory('Chainlink')).deploy(DEFAULT_CHAINLINK_EUR_USD_PRICE);
       TGateway = await TokenGatewayContract.deploy(TST.address);
-      BStorage = await StorageContract.deploy(TGateway.address, ChainlinkEurUsd.address, CHAINLINK_DEC);
+      BStorage = await StorageContract.deploy(TGateway.address, ChainlinkEurUsd.address, CHAINLINK_DEC, SEuro.address, USDT.address);
       BondingEvent = await BondingEventContract.deploy(
         SEuro.address, USDT.address, POSITION_MANAGER_ADDRESS, BStorage.address, owner.address,
         RatioCalculator.address, DEFAULT_SQRT_PRICE, MIN_TICK, MAX_TICK, MOST_STABLE_FEE

--- a/test/stage3/staking.js
+++ b/test/stage3/staking.js
@@ -395,7 +395,7 @@ describe('Staking', async () => {
   });
 
   describe('catastrophic events', async () => {
-    it('checks that the catastrophy event reverts in various situations', async () => {
+    it('checks that the catastrophe event reverts in various situations', async () => {
       let blockNum = await ethers.provider.getBlock();
       const then = blockNum.timestamp;
       const Staking = await StakingContract.deploy("Staking", "STS", then, then + 600, then + 5000, TGateway.address, TST_ADDRESS, SEUR_ADDRESS, simpleInterestRate);
@@ -404,17 +404,17 @@ describe('Staking', async () => {
       let active = await Staking.active();
       expect(active).to.eq(true);
 
-      cat = Staking.connect(user1).enableCatastrophy();
+      cat = Staking.connect(user1).enableCatastrophe();
       await expect(cat).to.be.revertedWith('Ownable: caller is not the owner');
 
-      cat = await Staking.enableCatastrophy();
-      let isCat = await Staking.isCatastrophy();
+      cat = await Staking.enableCatastrophe();
+      let isCat = await Staking.isCatastrophe();
       expect(isCat).to.eq(true);
 
       active = await Staking.active();
       expect(active).to.eq(false);
 
-      cat = Staking.connect(owner).enableCatastrophy();
+      cat = Staking.connect(owner).enableCatastrophe();
       await expect(cat).to.be.revertedWith('err-already-active');
     });
 
@@ -428,7 +428,7 @@ describe('Staking', async () => {
 
       // cannot withdraw cos we're not suspended
       let cat = Staking.connect(owner).emergencyWithdraw();
-      await expect(cat).to.be.revertedWith('err-not-catastrophy');
+      await expect(cat).to.be.revertedWith('err-not-catastrophe');
 
       const standardBalance = etherBalances["8K"];
       await TST.connect(owner).mint(user1.address, standardBalance);
@@ -437,8 +437,8 @@ describe('Staking', async () => {
       balance = await TST.balanceOf(user1.address);
       expect(balance).to.eq(0);
 
-      await Staking.connect(owner).enableCatastrophy();
-      let isCat = await Staking.isCatastrophy();
+      await Staking.connect(owner).enableCatastrophe();
+      let isCat = await Staking.isCatastrophe();
       expect(isCat).to.eq(true);
 
       // close
@@ -466,13 +466,13 @@ describe('Staking', async () => {
 
       // cannot withdraw cos we're not suspended
       let cat = Staking.connect(user1).emergencyWithdraw();
-      await expect(cat).to.be.revertedWith('err-not-catastrophy');
+      await expect(cat).to.be.revertedWith('err-not-catastrophe');
 
       balance = await TST.balanceOf(user1.address);
       expect(balance).to.eq(0);
 
-      await Staking.connect(owner).enableCatastrophy();
-      let isCat = await Staking.isCatastrophy();
+      await Staking.connect(owner).enableCatastrophe();
+      let isCat = await Staking.isCatastrophe();
       expect(isCat).to.eq(true);
 
       // close


### PR DESCRIPTION
- resolves #98 
- prevents new bonds or claiming of rewards when in catastrophe
- ensures there is enough of both assets in contracts to pay out principals, before enabling catastrophe
- corrects spelling of catastrophe in stage 3 😅 