### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Describe your changes
+
+## API / ABI
+
+## Checklist before requesting a review
+- [ ] I have verified that all tests pass
+- [ ] If the public API has changed, affecting the IBCO interaction, I have expressed it clearly above
+- [ ] If the ABI has changed, affecting auxiliary functionality, I have expressed it clearly above


### PR DESCRIPTION
Anticipate changes which may affect the frontend integration before opening a pull request.

Added two checkboxes to make a distinction whether: (1) the changes alter how the frontend calls the contracts (public API consumption), and (2) when the changes may modify auxiliary functionality (e.g., displaying data), both under the condition that the ABI changes in both of the two cases.